### PR TITLE
fix-toppage

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -28,5 +28,5 @@
         %li
           = link_to("お知らせ",'#') 
   .footer__logo
-    = link_to(image_tag('frema-logo-white'),'#')
+    = link_to(image_tag('frema-logo-white.svg'),'#')
   %p.footer__copyright © FURIMA


### PR DESCRIPTION
# error
ActionView::Template::Error (The asset "frema-logo-white" is not present in the asset pipeline.):
F, [2020-06-11T10:41:14.350368 #4190] FATAL -- : [c08bffee-1af9-4db2-9199-deef6133327e]     28:         %li
[c08bffee-1af9-4db2-9199-deef6133327e]     29:           = link_to("お知らせ",'#')
[c08bffee-1af9-4db2-9199-deef6133327e]     30:   .footer__logo
[c08bffee-1af9-4db2-9199-deef6133327e]     31:     = link_to(image_tag('frema-logo-white'),'#')
[c08bffee-1af9-4db2-9199-deef6133327e]     32:   %p.footer__copyright © FURIMA
F, [2020-06-11T10:41:14.350396 #4190] FATAL -- : [c08bffee-1af9-4db2-9199-deef6133327e]
F, [2020-06-11T10:41:14.350419 #4190] FATAL -- : [c08bffee-1af9-4db2-9199-deef6133327e] app/views/layouts/_footer.html.haml:31:in `_app_views_layouts__footer_html_haml___2512063306814347381_40694700'

# solution
 画像ファイルの拡張子を明記する